### PR TITLE
Prevent nil version

### DIFF
--- a/lib/renogen/cli.rb
+++ b/lib/renogen/cli.rb
@@ -67,6 +67,7 @@ module Renogen
     #
     # @param ticket_name [String]
     def self.new_ticket(ticket_name)
+      raise 'You need to provide a ticket_name' if ticket_name.nil?
       file_path = File.join(Config.instance.changelog_path, 'next', "#{ticket_name}.yml")
       File.open(file_path, 'w') do |f|
         Config.instance.default_headings.each do |h|


### PR DESCRIPTION
https://github.com/DDAZZA/renogen/issues/9

Quick fix to ensure you cannot have a nil version. No specs is pants but
we should add some coverage to the area in question in general.