### PR TITLE
change renogen markdown to match correct markdown for release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Next
+## Minor Improvement
+* Added newlines to html format
+* Fixed heading syntax in yaml
+
 # 1.2.0
 ## Improvement
 * Formatters may define their own header text for releases

--- a/lib/renogen/formatters/html.rb
+++ b/lib/renogen/formatters/html.rb
@@ -9,7 +9,7 @@ module Renogen
       # @param header [String]
       # @return [String]
       def write_header(header)
-        "<html>\n<h1>#{header}</h1>"
+        "<html>\n<h1>#{header}\n</h1>"
       end
 
       # Outputs a line or block as a header for a group.

--- a/lib/renogen/formatters/html.rb
+++ b/lib/renogen/formatters/html.rb
@@ -9,7 +9,7 @@ module Renogen
       # @param header [String]
       # @return [String]
       def write_header(header)
-        "<html>\n<h1>#{header}\n</h1>"
+        "<html>\n<h1>#{header}</h1>\n"
       end
 
       # Outputs a line or block as a header for a group.

--- a/lib/renogen/formatters/markdown.rb
+++ b/lib/renogen/formatters/markdown.rb
@@ -18,7 +18,7 @@ module Renogen
       # @param group [String]
       # @return [String]
       def write_group(group)
-        "## #{group}"
+        "## #{group}\n\n"
       end
 
       # Outputs a line or block as the body for a change.

--- a/lib/renogen/formatters/markdown.rb
+++ b/lib/renogen/formatters/markdown.rb
@@ -10,7 +10,7 @@ module Renogen
       # @param header [String]
       # @return [String]
       def write_header(header)
-        "# #{header}"
+        "# #{header}\n\n"
       end
 
       # Outputs a line or block as a header for a group.

--- a/lib/renogen/formatters/markdown.rb
+++ b/lib/renogen/formatters/markdown.rb
@@ -18,7 +18,7 @@ module Renogen
       # @param group [String]
       # @return [String]
       def write_group(group)
-        "### #{group}"
+        "## #{group}"
       end
 
       # Outputs a line or block as the body for a change.

--- a/spec/lib/renogen/formatters/html_spec.rb
+++ b/spec/lib/renogen/formatters/html_spec.rb
@@ -8,7 +8,7 @@ describe Renogen::Formatters::Html do
 
   describe '#write_header' do
     it 'returns header with newline' do
-      expect(subject.write_header('header')).to eql "<html>\n<h1>header\n</h1>"
+      expect(subject.write_header('header')).to eql "<html>\n<h1>header</h1>\n"
     end
   end
 

--- a/spec/lib/renogen/formatters/html_spec.rb
+++ b/spec/lib/renogen/formatters/html_spec.rb
@@ -8,7 +8,7 @@ describe Renogen::Formatters::Html do
 
   describe '#write_header' do
     it 'returns header with newline' do
-      expect(subject.write_header('header')).to eql "<html>\n<h1>header</h1>"
+      expect(subject.write_header('header')).to eql "<html>\n<h1>header\n</h1>"
     end
   end
 

--- a/spec/lib/renogen/formatters/markdown_spec.rb
+++ b/spec/lib/renogen/formatters/markdown_spec.rb
@@ -11,7 +11,7 @@ describe Renogen::Formatters::Markdown do
 
   describe '#write_header' do
     it 'returns header with newline' do
-      expect(subject.write_header('header')).to eql "# header"
+      expect(subject.write_header('header')).to eql "# header\n\n"
     end
   end
 

--- a/spec/lib/renogen/formatters/markdown_spec.rb
+++ b/spec/lib/renogen/formatters/markdown_spec.rb
@@ -17,7 +17,7 @@ describe Renogen::Formatters::Markdown do
 
   describe '#write_group' do
     it 'returns group' do
-      expect(subject.write_group('group')).to eql "### group"
+      expect(subject.write_group('group')).to eql "## group"
     end
   end
 

--- a/spec/lib/renogen/formatters/markdown_spec.rb
+++ b/spec/lib/renogen/formatters/markdown_spec.rb
@@ -17,7 +17,7 @@ describe Renogen::Formatters::Markdown do
 
   describe '#write_group' do
     it 'returns group' do
-      expect(subject.write_group('group')).to eql "## group"
+      expect(subject.write_group('group')).to eql "## group\n\n"
     end
   end
 


### PR DESCRIPTION
using '##' instead of '###' for headers and having a new line to split each section