### PR TITLE
Adds support for validating default headings with allowed values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,42 @@
+# 1.3.0
+
+## Improvement
+
+* Adds the ability for any default heading to specify valid values only.
+
 # 1.2.1
+
 ## Minor Improvement
+
 * Added newlines to html format
 * Fixed heading syntax in YAML
 
 # 1.2.0
+
 ## Improvement
+
 * Formatters may define their own header text for releases
 * Allow using a custom release date
 * Allow including Ruby files (useful for using custom formatters)
 
 # 1.1.1
+
 ## Minor
+
 * Fixed gemspec date
 
 # 1.1.0
+
 ## Improvement
+
 * Added 'new' argument to create new template ticket
 
 # 1.0.1
+
 ## Minor Improvement
+
 * Allow empty content under heading in change file
 
 # 1.0.0
+
 Initial Release

--- a/README.md
+++ b/README.md
@@ -2,42 +2,68 @@
 
 Renogen or Re(lease) No(tes) Gen(erator) is a development tool to separate feature notes from product versions.
 
-
 This renogen can not do and will have to be reviewed manually
+
 - Order the notes in the orrect order (e.g. if a task has to be run before/after something else)
 - Remove Duplicate notes that might be added (e.g. 2 tickets might want to run the same task)
 
+## Contents
 
-### Installation
+- [Installation](#Installation)
+- [Usage](#Usage)
+- [Configuration](#Configuration)
+- [Frequently Asked Questions](#FAQ)
+- [License](#License)
+
+<a name="Installation"></a>
+## Installation
 
 To install Renogen, use the following command:
 
-`$ gem install renogen`
+```
+$ gem install renogen
+```
 
-or add the following to your Gemfile
+or add the following to your Gemfile when using Bundler
 
-`gem 'renogen', :require => false, :group => :development`
+```
+gem 'renogen', require: false, group: :development
+```
 
-`$ renogen init # optional  Creates directory for notes`
+and run
 
-`$ renogen --help # List available options`
+```
+bundle install
+```
 
-### Usage
+Now, you may initialize your repository with a `change_log` directory and a basic `.renogen` config file:
+
+```
+$ renogen init` # optional  Creates directory for notes
+```
+
+<a name="Usage"></a>
+## Usage
 
 To generate your notes run the following command
 
-`$ renogen <VERSION> # e.g v1.2.1`
+```
+$ renogen <VERSION> # e.g v1.2.1
+```
 
 Unfortunatly renogen cant write documentation for your change.
 By default renogen uses the yaml file stratagy to extract your notes
 
-`$ renogen --help # list available command options`
+```
+$ renogen --help # list available command options
+```
 
-#### Adding YAML feature notes
+### Adding YAML feature notes
 
-Create a new file within the 'next' version folder(default:'change_log/next/')
+You can create a new file within the 'next' version folder (default: `change_log/next/`) manually:
 
-Example feature note
+Example feature note:
+
 ```yaml
 # change_log/next/example.yml
 my_formatted_single_line:
@@ -59,31 +85,73 @@ my_list:
   - e.g. run this as well
 ```
 
-#### Usage Examples
+You can also use the `new` command to create a feature note YAML file in the 'next' version folder:
 
-Prepend your notes to a changelog file(TODO make command simple)
+```
+$ renogen new TICKET_NAME # creates ./change_log/next/TICKET_NAME.yml`
+```
 
-`$ renogen --format markdown v1.2.1 > CHANGELOG.md | cat - CHANGELOG > CHANGELOG.tmp && mv CHANGELOG.tmp CHANGELOG`
+### Usage Examples
+
+Prepend your notes to a changelog file (TODO make command simple)
+
+```
+$ renogen --format markdown v1.2.1 > CHANGELOG.md | cat - CHANGELOG > CHANGELOG.tmp && mv CHANGELOG.tmp CHANGELOG
+```
 
 Writes notes to html file
 
-`$ renogen --format html v1.2.1 > v1_2_1.html`
+```
+$ renogen --format html v1.2.1 > v1_2_1.html
+```
 
 Print all notes since v1.0.0 as text
 
-`$ renogen --format text -l v1.0.0 v1.2.1`
+```
+$ renogen --format text -l v1.0.0 v1.2.1
+```
 
-### Configuration
+<a name="Configuration"></a>
+## Configuration
 
-TODO
-* How to set configuration with `.renogen` file
-* How to change formatted single line
+Renogen tries to read the file `.renogen` in the working directory to load its configuration. The file is in YAML format
+with the following keys:
+
+|       key            | meaning | default value | configuration example |
+|----------------------|----------|---------------|-----------------------|
+| `single_line_format` | A template for generating a single line of text from a YAML dictionary in a feature note file. Each dictionary key in the template gets replaced by the value for that key. | `summary (see link)` | `[#ticket](https://github.com/renogen/issue/ticket): summary` |
+| `supported_keys`     | YAML dictionary keys allowed in dictionary feature notes. Ignored for dictionaries where rules apply. | `%w[identifier summary link]` | |
+| `input_source`       | The format of the feature note files. Currently, only `yaml` is supported. | `yaml` | |
+| `output_format`      | The default output format when generating release notes. | `markdown` | `html` |
+| `changelog_path`     | The directory where the feature note files are stored. | `./change_log` | `./doc/src/changes` |
+| `default_headings`   | The headings/group names that will be printed into a feature note file created by the `new` command. Ignored when there is a rule defined for the given file name. | `%w[Summary Detailed Tasks]` | `%w[Title Description Deployment]` |
+| `allowed_values`     | Allowed values for default headings.  See [Allowed Values](#AllowedValues). | `{}` (none) |  |
+
+<a name="AllowedValues"></a>
+## Allowed Values
+
+Allowed values enables you to specify a range of allowed values for any default heading. This can be an array, string or
+regular expression:
+
+```yaml
+default_headings:
+  - Products
+  - Countries
+  - User Facing
+Products: !ruby/regexp '/\b(Foo|Bar)\b/'
+Countries: [UK, AUS, FR]
+User Facing: Yes
+```
+
+<a name="FAQ"></a>
+## Frequently Asked Questions
 
 ### Custom formatter
 
 You can use your own formatter quite easily.
 
 For example, put this in `lib/my_project/renogen_formatter.rb`:
+
 ```ruby
 require 'renogen/formatters'
 
@@ -114,23 +182,28 @@ end
 
 You have to include that file when running renogen:
 
-`$ renogen -I. -Rlib/my_project/renogen_formatter 1.2.3`
+```
+$ renogen -I. -Rlib/my_project/renogen_formatter 1.2.3
+```
 
-### Why does renogen not use renogen?
+### Why does renogen not use renogen
+
 The amount of activity and contributes for this project is small and so it is more practical to use a text file.
 
-### How can I run from source?
+### How can I run from source
+
 ```
 $ git clone git@github.com:DDAZZA/renogen.git
 $ cd ./renogen/
 $ bundle install
 $ bundle exec ./bin/renogen test
 ```
-### License
+
+## License
 
 Renogen is a programming tool to generate a log of source code changes
 
-Copyright (C) 2015 David Elliott
+Copyright (C) 2015-2020 David Elliott
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/lib/renogen/change_log.rb
+++ b/lib/renogen/change_log.rb
@@ -5,5 +5,6 @@ module Renogen
     require_relative 'change_log/group'
     require_relative 'change_log/writer'
     require_relative 'change_log/model'
+    require_relative 'change_log/validator'
   end
 end

--- a/lib/renogen/change_log/item.rb
+++ b/lib/renogen/change_log/item.rb
@@ -15,6 +15,7 @@ module Renogen
       # @return [String]
       def to_s
         return '' unless change
+
         case change.class.to_s
         when 'String'
           format_multiline(change)
@@ -46,12 +47,12 @@ module Renogen
       end
 
       def format_array(change)
-        # TODO should return a string
+        # TODO: should return a string
         change
       end
 
       def format_oneline(change)
-        # TODO Refactor
+        # TODO: Refactor
         string = config.single_line_format.downcase.gsub('\n', '\n  ')
         config.supported_keys.each do |key|
           string = string.gsub(key, '#{change[\'' + key + '\']}')

--- a/lib/renogen/change_log/validator.rb
+++ b/lib/renogen/change_log/validator.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Renogen
+  module ChangeLog
+    # Validates the change log
+    class Validator
+      def initialize(formatter)
+        @formatter = formatter
+        @validations = formatter.options['validations']
+      end
+
+      # Validates the change log
+      #
+      # @param changelog [ChangeLog::Model]
+      def validate!(changelog)
+        validate_headings(changelog)
+      end
+
+      protected
+
+      attr_reader :formatter, :validations
+
+      def validate_headings(changelog)
+        return if validations.nil?
+        return if changelog.items.none? { |item| validations.key?(item.group_name) }
+
+        validate_properties(changelog)
+      end
+
+      private
+
+      def validate_properties(changelog)
+        invalid_items = []
+        validations.each do |heading, values|
+          items_to_select = changelog.items.select { |log| log.group_name == heading }
+          invalid_values = items_to_select.map { |i| (changes_to_validate(i.change) - values) }.flatten.uniq
+          next if invalid_values.empty?
+
+          invalid_items << { invalid_value: invalid_values, valid_values: values, group_name: heading }
+        end
+
+        invalid_items = invalid_items.flatten
+        raise(Renogen::Exceptions::InvalidItemFound, invalid_items) unless invalid_items.empty?
+      end
+
+      def changes_to_validate(change)
+        return [change] if change.is_a? String
+
+        change
+      end
+    end
+  end
+end

--- a/lib/renogen/cli.rb
+++ b/lib/renogen/cli.rb
@@ -21,6 +21,7 @@ module Renogen
       options['changelog_path'] ||= config_instance.changelog_path
       options['old_version'] ||= config_instance.changelog_path
       options['release_date'] ||= Date.today
+      options['validations'] ||= config_instance.validations
 
       begin
         generator = Renogen::Generator.new(version, source, format, options)
@@ -33,14 +34,14 @@ module Renogen
 
     # Initialize the current working directory with an example change
     def self.init
-      # TODO Refactor to use Config.instance.changelog_path
+      # TODO: Refactor to use Config.instance.changelog_path
       Dir.mkdir('./change_log')
       puts "Created './change_log/'"
 
       Dir.mkdir('./change_log/next')
       puts "Created './change_log/next/'"
 
-      File.open("./change_log/next/added_renogen_gem.yml", 'w') do |f|
+      File.open('./change_log/next/added_renogen_gem.yml', 'w') do |f|
         f.write("Summary:\n")
         f.write("  identifier: renogen\n")
         f.write("  link: https://github.com/DDAZZA/renogen\n")
@@ -57,7 +58,7 @@ module Renogen
 
       puts "Created './change_log/next/added_renogen_gem.yml'"
 
-      File.open(".renogen", 'w') do |f|
+      File.open('.renogen', 'w') do |f|
         f.write("changelog_path: './change_log/'\n")
       end
       puts "Created '.renogen'"
@@ -68,6 +69,7 @@ module Renogen
     # @param ticket_name [String]
     def self.new_ticket(ticket_name)
       raise 'You need to provide a ticket_name' if ticket_name.nil?
+
       file_path = File.join(Config.instance.changelog_path, 'next', "#{ticket_name}.yml")
       File.open(file_path, 'w') do |f|
         Config.instance.default_headings.each do |h|

--- a/lib/renogen/cli.rb
+++ b/lib/renogen/cli.rb
@@ -21,7 +21,7 @@ module Renogen
       options['changelog_path'] ||= config_instance.changelog_path
       options['old_version'] ||= config_instance.changelog_path
       options['release_date'] ||= Date.today
-      options['validations'] ||= config_instance.validations
+      options['allowed_values'] ||= config_instance.validations
 
       begin
         generator = Renogen::Generator.new(version, source, format, options)

--- a/lib/renogen/config.rb
+++ b/lib/renogen/config.rb
@@ -18,7 +18,7 @@ module Renogen
       self.output_format = config_file['output_format'] || 'markdown'
       self.changelog_path = config_file['changelog_path'] || './change_log'
       self.default_headings = config_file['default_headings'] || %w(Summary Detailed Tasks)
-      self.validations = config_file['validations']
+      self.validations = config_file['allowed_values']
     end
 
     # Renogen configuration extension

--- a/lib/renogen/config.rb
+++ b/lib/renogen/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'singleton'
 require 'yaml'
 
@@ -5,18 +7,19 @@ module Renogen
   # Stores configuratin values to be used by the libary
   class Config
     include Singleton
-    attr_accessor :single_line_format, :input_source, :output_format, :supported_keys, :changelog_path, :default_headings
+    attr_accessor :single_line_format, :input_source, :output_format, :supported_keys, :changelog_path,
+                  :default_headings, :validations
 
     def initialize
       config_file = load_yaml_config
-      self.single_line_format = config_file['single_line_format'] || 'summary (see link)'.freeze
-      self.supported_keys = config_file['supported_keys'] || ['identifier', 'link', 'summary'].freeze
-      self.input_source = config_file['input_source'] || 'yaml'.freeze
-      self.output_format = config_file['output_format'] || 'markdown'.freeze
-      self.changelog_path = config_file['changelog_path'] || './change_log'.freeze
-      self.default_headings = config_file['default_headings'] || %w(Summary Detailed Tasks).freeze
+      self.single_line_format = config_file['single_line_format'] || 'summary (see link)'
+      self.supported_keys = config_file['supported_keys'] || %w(identifier link summary)
+      self.input_source = config_file['input_source'] || 'yaml'
+      self.output_format = config_file['output_format'] || 'markdown'
+      self.changelog_path = config_file['changelog_path'] || './change_log'
+      self.default_headings = config_file['default_headings'] || %w(Summary Detailed Tasks)
+      self.validations = config_file['validations']
     end
-
 
     # Renogen configuration extension
     # a block can be provided to programatily setup configuration values
@@ -26,13 +29,10 @@ module Renogen
 
     private
 
-    def load_yaml_config(config_file_path='.renogen')
-      begin
-        YAML.load_file(config_file_path)
-      rescue
-        {}
-      end
+    def load_yaml_config(config_file_path = '.renogen')
+      YAML.load_file(config_file_path)
+    rescue StandardError
+      {}
     end
   end
 end
-

--- a/lib/renogen/exceptions.rb
+++ b/lib/renogen/exceptions.rb
@@ -1,7 +1,10 @@
+# frozen_string_literal: true
+
 module Renogen
   # Custom exceptions throw by the libary
   module Exceptions
     require_relative 'exceptions/base'
     require_relative 'exceptions/stratagy_not_found'
+    require_relative 'exceptions/invalid_item_found'
   end
 end

--- a/lib/renogen/exceptions/invalid_item_found.rb
+++ b/lib/renogen/exceptions/invalid_item_found.rb
@@ -18,7 +18,12 @@ module Renogen
         messages = ['Invalid items:']
         invalid_items.each do |item|
           invalid_value = item[:invalid_value]
-          messages << "Group: #{item[:group_name]}, Content: #{invalid_value}, Valid Value: #{item[:valid_values]}"
+
+          messages << if item[:valid_values].is_a?(Regexp)
+            "Group: #{item[:group_name]}, Content: #{invalid_value}, Pattern: #{item[:valid_values].inspect}"
+          else
+            "Group: #{item[:group_name]}, Content: #{invalid_value}, Valid Values: #{item[:valid_values]}"
+          end
         end
         messages.join("\n")
       end

--- a/lib/renogen/exceptions/invalid_item_found.rb
+++ b/lib/renogen/exceptions/invalid_item_found.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Renogen
+  module Exceptions
+    # Raised when change log contains invalid items.
+    class InvalidItemFound < Base
+      attr_reader :invalid_items
+
+      def initialize(invalid_items)
+        @invalid_items = invalid_items
+        super
+      end
+
+      # Friendly error message
+      #
+      # @return [String]
+      def message
+        messages = ['Invalid items:']
+        invalid_items.each do |item|
+          invalid_value = item[:invalid_value]
+          messages << "Group: #{item[:group_name]}, Content: #{invalid_value}, Valid Value: #{item[:valid_values]}"
+        end
+        messages.join("\n")
+      end
+    end
+  end
+end

--- a/lib/renogen/formatters/base.rb
+++ b/lib/renogen/formatters/base.rb
@@ -1,9 +1,14 @@
+# frozen_string_literal: true
+
 module Renogen
   module Formatters
-    # Implements a template pattern that forces the implemention of required 
+    # Implements a template pattern that forces the implemention of required
     # methods in sub classes
     class Base
-      def initialize(options={})
+      attr_reader :options
+
+      def initialize(options = {})
+        @options = options
       end
 
       # Adds class with identifier to formatters

--- a/lib/renogen/generator.rb
+++ b/lib/renogen/generator.rb
@@ -18,7 +18,7 @@ module Renogen
       changelog.version = version
       changelog.date = options['release_date']
 
-      validator.validate!(changelog) if options['validations'].any?
+      validator.validate!(changelog) if options['validations']&.any?
       writer.write!(changelog)
     end
 

--- a/lib/renogen/generator.rb
+++ b/lib/renogen/generator.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 module Renogen
   # This is the conductor of the application
   class Generator
     attr_accessor :source, :version, :output_format, :options
 
-    def initialize(version, source, output_format, options={})
+    def initialize(version, source, output_format, options = {})
       @version = version
       @source = source
       @output_format = output_format
@@ -16,6 +18,7 @@ module Renogen
       changelog.version = version
       changelog.date = options['release_date']
 
+      validator.validate!(changelog) if options['validations'].any?
       writer.write!(changelog)
     end
 
@@ -31,6 +34,10 @@ module Renogen
 
     def formatter
       Renogen::Formatters.obtain(output_format, options)
+    end
+
+    def validator
+      Renogen::ChangeLog::Validator.new(formatter)
     end
   end
 end

--- a/lib/renogen/generator.rb
+++ b/lib/renogen/generator.rb
@@ -18,7 +18,7 @@ module Renogen
       changelog.version = version
       changelog.date = options['release_date']
 
-      validator.validate!(changelog) if options['validations']&.any?
+      validator.validate!(changelog) if options['allowed_values']&.any?
       writer.write!(changelog)
     end
 

--- a/lib/renogen/version.rb
+++ b/lib/renogen/version.rb
@@ -1,3 +1,3 @@
 module Renogen
-  VERSION='1.2.1'.freeze # :nodoc:
+  VERSION = '1.3.0'.freeze # :nodoc:
 end

--- a/renogen.gemspec
+++ b/renogen.gemspec
@@ -1,19 +1,23 @@
-$:.push File.expand_path("../lib", __FILE__)
+# frozen_string_literal: true
+
+$LOAD_PATH.push File.expand_path('lib', __dir__)
 require 'renogen/version'
 
 Gem::Specification.new do |s|
   s.name        = 'renogen'
   s.version     = Renogen::VERSION
   s.date        = '2019-07-09'
-  s.summary     = "Release Notes/changelog Generator"
-  s.description = "A tool to separate product feature release notes from the product versions."
-  s.authors     = "Dave Elliott"
+  s.summary     = 'Release Notes/changelog Generator'
+  s.description = 'A tool to separate product feature release notes from the product versions.'
+  s.authors     = 'Dave Elliott'
   s.email       = 'ddazza@gmail.com'
-  s.files       = Dir.glob("{bin,lib,spec}/**/**/**") + %w(README.md LICENSE) 
+  s.files       = Dir.glob('{bin,lib,spec}/**/**/**') + %w(README.md LICENSE)
   s.homepage    = 'https://github.com/DDAZZA/renogen'
   s.license     = 'GPL-3.0'
   s.executables << 'renogen'
   s.required_ruby_version = '~> 2.0'
 
+  s.add_development_dependency 'pry'
+  s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rspec', '~> 3.0'
 end

--- a/spec/lib/renogen/change_log/validator_spec.rb
+++ b/spec/lib/renogen/change_log/validator_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Renogen::ChangeLog::Validator do
+  let(:change_log) { Renogen::ChangeLog::Model.new }
+  let(:validations) { { 'foo' => %w(bar baz) } }
+
+  subject { described_class.new(double('Formatter', options: { 'validations' => validations })) }
+
+  before(:each) { change_log.add_change(Renogen::ChangeLog::Item.new('foo', 'bar')) }
+
+  describe '#validate!' do
+    context 'when no validations are available' do
+      let(:validations) { nil }
+
+      it 'successfully passes the validation process' do
+        expect { subject.validate!(change_log) }.to_not raise_error
+        subject.validate!(change_log)
+      end
+    end
+
+    context 'when validation is successful' do
+      it 'successfully passes the validation process' do
+        expect { subject.validate!(change_log) }.to_not raise_error
+        subject.validate!(change_log)
+      end
+    end
+
+    context 'when validation has failed' do
+      let(:validations) { { 'foo' => ['baz'] } }
+
+      it 'fails validation' do
+        expect { subject.validate!(change_log) }.to raise_error(Renogen::Exceptions::InvalidItemFound)
+      end
+    end
+  end
+end

--- a/spec/lib/renogen/change_log/validator_spec.rb
+++ b/spec/lib/renogen/change_log/validator_spec.rb
@@ -6,7 +6,7 @@ describe Renogen::ChangeLog::Validator do
   let(:change_log) { Renogen::ChangeLog::Model.new }
   let(:validations) { { 'foo' => %w(bar baz) } }
 
-  subject { described_class.new(double('Formatter', options: { 'validations' => validations })) }
+  subject { described_class.new(double('Formatter', options: { 'allowed_values' => validations })) }
 
   before(:each) { change_log.add_change(Renogen::ChangeLog::Item.new('foo', 'bar')) }
 

--- a/spec/lib/renogen/config_spec.rb
+++ b/spec/lib/renogen/config_spec.rb
@@ -1,19 +1,24 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Renogen::Config do
-
   subject { described_class.instance }
 
   describe '#configure' do
     before :each do
       described_class.configure do |config|
         config.single_line_format = 'bar'
+        config.validations = ['test']
       end
     end
 
     it 'can set value' do
       expect(subject.single_line_format).to eql 'bar'
     end
-  end
 
+    it 'sets the validations value' do
+      expect(subject.validations).to eql ['test']
+    end
+  end
 end

--- a/spec/lib/renogen/exceptions/invalid_item_found_spec.rb
+++ b/spec/lib/renogen/exceptions/invalid_item_found_spec.rb
@@ -3,32 +3,33 @@
 require 'spec_helper'
 
 describe Renogen::Exceptions::InvalidItemFound do
-  let(:invalid_items) do
-    [
-      {
-        group_name: 'Product',
-        invalid_value: 'Foo',
-        valid_values: %w(Bar Baz)
-      },
-      {
-        group_name: 'Country',
-        invalid_value: 'LL',
-        valid_values: %w(UK IE)
-      }
-    ]
-  end
-
   subject { described_class.new(invalid_items) }
 
   describe '#message' do
-    let(:expected_error) do
-      "Invalid items:
-Group: Product, Content: Foo, Valid Value: [\"Bar\", \"Baz\"]
-Group: Country, Content: LL, Valid Value: [\"UK\", \"IE\"]"
+    context 'valid_values is an array' do
+      let(:invalid_items) do
+        [
+          { group_name: 'Product', invalid_value: 'Foo', valid_values: %w(Bar Baz) },
+          { group_name: 'Country', invalid_value: 'LL', valid_values: %w(UK IE) }
+        ]
+      end
+      let(:expected_error) do
+        "Invalid items:\nGroup: Product, Content: Foo, Valid Values: [\"Bar\", \"Baz\"]" \
+        "\nGroup: Country, Content: LL, Valid Values: [\"UK\", \"IE\"]"
+      end
+
+      it 'returns a user friendly error message' do
+        expect(subject.message).to eql expected_error
+      end
     end
 
-    it 'returns a user friendly error message' do
-      expect(subject.message).to eql expected_error
+    context 'valid_values is a RegExp' do
+      let(:invalid_items) { [{ group_name: 'Product', invalid_value: 'Foo', valid_values: /\b(Bar|Baz)\b/ }] }
+      let(:expected_error) { "Invalid items:\nGroup: Product, Content: Foo, Pattern: #{/\b(Bar|Baz)\b/.inspect}" }
+
+      it 'returns a user friendly error message' do
+        expect(subject.message).to eql expected_error
+      end
     end
   end
 end

--- a/spec/lib/renogen/exceptions/invalid_item_found_spec.rb
+++ b/spec/lib/renogen/exceptions/invalid_item_found_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Renogen::Exceptions::InvalidItemFound do
+  let(:invalid_items) do
+    [
+      {
+        group_name: 'Product',
+        invalid_value: 'Foo',
+        valid_values: %w(Bar Baz)
+      },
+      {
+        group_name: 'Country',
+        invalid_value: 'LL',
+        valid_values: %w(UK IE)
+      }
+    ]
+  end
+
+  subject { described_class.new(invalid_items) }
+
+  describe '#message' do
+    let(:expected_error) do
+      "Invalid items:
+Group: Product, Content: Foo, Valid Value: [\"Bar\", \"Baz\"]
+Group: Country, Content: LL, Valid Value: [\"UK\", \"IE\"]"
+    end
+
+    it 'returns a user friendly error message' do
+      expect(subject.message).to eql expected_error
+    end
+  end
+end

--- a/spec/lib/renogen/exceptions/stratagy_not_found_spec.rb
+++ b/spec/lib/renogen/exceptions/stratagy_not_found_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Renogen::Exceptions::StratagyNotFound do
@@ -8,6 +10,5 @@ describe Renogen::Exceptions::StratagyNotFound do
     it 'returns friendly error message' do
       expect(subject.message).to eql "Error: Stratagy type '#{name}' not found"
     end
-
   end
 end


### PR DESCRIPTION
```
default_headings:
  - Products
  - Countries
validations:
  Products: [Tier 1, Tier 2]
  Countries: [UK, IE, AUS]
```

By adding the following to your `.renogen` file you can now provide allowed values for any default heading. When generating the changelog, if any invalid entries exist, an exception is raised and outputs the invalid items in the changelog.