### PR TITLE
Adds custom writer classes to enable CSV output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,2 @@
 source "https://rubygems.org"
 gemspec
-

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Writes notes to html file
 
 `$ renogen --format html v1.2.1 > v1_2_1.html`
 
+Writes note to csv file
+
+`$ renogen --format csv v1.2.1 > v1_2_1.csv`
+
 Print all notes since v1.0.0 as text
 
 `$ renogen --format text -l v1.0.0 v1.2.1`

--- a/lib/renogen.rb
+++ b/lib/renogen.rb
@@ -9,4 +9,5 @@ module Renogen
   require 'renogen/change_log'
   require 'renogen/generator'
   require 'renogen/config'
+  require 'renogen/writers'
 end

--- a/lib/renogen/change_log.rb
+++ b/lib/renogen/change_log.rb
@@ -3,7 +3,6 @@ module Renogen
   module ChangeLog
     require_relative 'change_log/item'
     require_relative 'change_log/group'
-    require_relative 'change_log/writer'
     require_relative 'change_log/model'
   end
 end

--- a/lib/renogen/change_log/model.rb
+++ b/lib/renogen/change_log/model.rb
@@ -4,13 +4,14 @@ module Renogen
   module ChangeLog
     # Object to represent a Changelog/release notes
     class Model
-      attr_reader :items
+      attr_reader :items, :files
       attr_accessor :version, :date
 
       def initialize(options={})
         @version = options[:version]
         @date = options[:date] || Date.today
         @items = []
+        @files = []
       end
 
       # @return [Hash<group_name: change>]
@@ -29,6 +30,15 @@ module Renogen
       def add_change(change)
         raise TypeError unless change.is_a?(Renogen::ChangeLog::Item)
         items << change
+      end
+
+      # Adds a raw YAML file hash to the changelog
+      #
+      # @param file [Hash]
+      # @return [Array] All files
+      def add_file(file)
+        raise TypeError unless file.is_a?(Hash)
+        files << file
       end
     end
   end

--- a/lib/renogen/extraction_stratagies/yaml_file/parser.rb
+++ b/lib/renogen/extraction_stratagies/yaml_file/parser.rb
@@ -24,6 +24,7 @@ module Renogen
         attr_reader :yaml_file_reader
 
         def parse_file(file)
+          changelog.add_file(file)
           file.each do |group_name, content|
             changelog.add_change(ChangeLog::Item.new(group_name, content))
           end

--- a/lib/renogen/formatters.rb
+++ b/lib/renogen/formatters.rb
@@ -37,6 +37,7 @@ module Renogen
   end
 
   require_relative 'formatters/base'
+  require_relative 'formatters/csv'
   require_relative 'formatters/plain_text'
   require_relative 'formatters/markdown'
   require_relative 'formatters/html'

--- a/lib/renogen/formatters/base.rb
+++ b/lib/renogen/formatters/base.rb
@@ -1,6 +1,6 @@
 module Renogen
   module Formatters
-    # Implements a template pattern that forces the implemention of required 
+    # Implements a template pattern that forces the implemention of required
     # methods in sub classes
     class Base
       def initialize(options={})
@@ -32,6 +32,16 @@ module Renogen
         raise NotImplementedError
       end
 
+      # Outputs a line or block listing all group headings found in the change log.
+      #
+      # @abstract
+      #
+      # @param changelog [Renogen::ChangeLog::Model]
+      # @raise NotImplementedError
+      def write_headings(changelog)
+        raise NotImplementedError
+      end
+
       # Outputs a line or block as a header for a group.
       #
       # @abstract
@@ -55,6 +65,16 @@ module Renogen
       # @param change [String]
       # @raise NotImplementedError
       def write_change(change)
+        raise NotImplementedError
+      end
+
+      # Outputs the hash contents of a full YAML release notes file
+      #
+      # @abstract
+      #
+      # @param file [Hash]
+      # @raise NotImplementedError
+      def write_file(file)
         raise NotImplementedError
       end
 

--- a/lib/renogen/formatters/csv.rb
+++ b/lib/renogen/formatters/csv.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Renogen
+  module Formatters
+    # For formatting a change into CSV output
+    class Csv < Base
+      register :csv
+
+      def write_headings(changelog)
+        headers(changelog).join(',')
+      end
+
+      def write_file(file, changelog)
+        output = []
+
+        headers(changelog).each do |header|
+          raw_line = file[header]
+          parsed_line = raw_line.is_a?(Array) ? raw_line.join(',') : raw_line
+          output << "\"#{parsed_line}\""
+        end
+
+        output.join(',')
+      end
+
+      private
+
+      def headers(changelog)
+        changelog.groups.keys
+      end
+    end
+  end
+end

--- a/lib/renogen/generator.rb
+++ b/lib/renogen/generator.rb
@@ -22,7 +22,7 @@ module Renogen
     protected
 
     def writer
-      Renogen::ChangeLog::Writer.new(formatter)
+      Renogen::Writers.obtain(output_format, formatter)
     end
 
     def extraction_stratagy

--- a/lib/renogen/writers.rb
+++ b/lib/renogen/writers.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Renogen
+  # Writers allow customisation of the structure and layout of formatted output
+  module Writers
+    class << self
+      # Retrieves a writer from a given key, and initialises with given formatter
+      #
+      # @param format_type [String] identifier for writer
+      # @param formatter [Renogen::Formatters::Base] formatter to initialise writer with
+      # @return [Writers::Base]
+      def obtain(format_type, formatter)
+        writer = writers[format_type.to_sym]
+        return writer.new(formatter) if writer
+
+        writers[:default].new(formatter)
+      end
+
+      # Adds a new writer class to store
+      #
+      # @param identifier [Symbol]
+      # @param klass [Symbol]
+      def add(identifiers, klass)
+        identifiers.each do |identifier|
+          writers[identifier] = klass
+        end
+      end
+
+      private
+
+      def writers
+        @writers ||= {}
+      end
+    end
+  end
+
+  require_relative 'writers/base'
+  require_relative 'writers/csv'
+  require_relative 'writers/html'
+  require_relative 'writers/markdown'
+  require_relative 'writers/plain_text'
+end

--- a/lib/renogen/writers/base.rb
+++ b/lib/renogen/writers/base.rb
@@ -1,7 +1,16 @@
 module Renogen
-  module ChangeLog
+  module Writers
     # Writes out the change log
-    class Writer
+    class Base
+      # Adds class with identifier to writers
+      #
+      # @param identifier [String]
+      def self.register(*identifiers)
+        Renogen::Writers.add(identifiers.map(&:to_sym), self)
+      end
+      # Register base class as default writer to support custom formatters
+      register :default
+
       def initialize(formatter)
         @formatter = formatter
       end
@@ -33,6 +42,10 @@ module Renogen
           changes.each { |change| output_change(change) }
           puts formatter.write_group_end
         end
+      end
+
+      def output_files(files)
+        raise NotImplementedError
       end
     end
   end

--- a/lib/renogen/writers/csv.rb
+++ b/lib/renogen/writers/csv.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Renogen
+  module Writers
+    # Writes out the change log in CSV format
+    class Csv < Base
+      register :csv
+
+      def write!(changelog)
+        puts formatter.write_headings(changelog)
+        output_files(changelog)
+      end
+
+      private
+
+      def output_files(changelog)
+        changelog.files.each do |file|
+          puts formatter.write_file(file, changelog)
+        end
+      end
+    end
+  end
+end

--- a/lib/renogen/writers/html.rb
+++ b/lib/renogen/writers/html.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Renogen
+  module Writers
+    # Writes out the change log in HTML format
+    class Html < Base
+      register :html
+    end
+  end
+end

--- a/lib/renogen/writers/markdown.rb
+++ b/lib/renogen/writers/markdown.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Renogen
+  module Writers
+    # Writes out the change log in markdown format
+    class Markdown < Base
+      register :markdown, :md
+    end
+  end
+end

--- a/lib/renogen/writers/plain_text.rb
+++ b/lib/renogen/writers/plain_text.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Renogen
+  module Writers
+    # Writes out the change log in plain text format
+    class PlainText < Base
+      register :text, :plain_text
+    end
+  end
+end

--- a/spec/lib/renogen/change_log/writer_spec.rb
+++ b/spec/lib/renogen/change_log/writer_spec.rb
@@ -1,8 +1,0 @@
-require 'spec_helper'
-
-describe Renogen::ChangeLog::Writer do
-
-  describe '#write!' do
-  end
-end
-

--- a/spec/lib/renogen/formatters/base_spec.rb
+++ b/spec/lib/renogen/formatters/base_spec.rb
@@ -17,6 +17,14 @@ describe Renogen::Formatters::Base do
     end
   end
 
+  describe '#write_headings' do
+    let(:changelog) { double(Renogen::ChangeLog::Model) }
+
+    it 'raises an NotImplementedError' do
+      expect{subject.write_headings(changelog)}.to raise_error NotImplementedError
+    end
+  end
+
   describe '#write_group' do
     it 'raises an NotImplementedError' do
       expect{subject.write_group('group_name')}.to raise_error NotImplementedError
@@ -26,6 +34,12 @@ describe Renogen::Formatters::Base do
   describe '#write_change' do
     it 'raises an NotImplementedError' do
       expect{subject.write_change('change')}.to raise_error NotImplementedError
+    end
+  end
+
+  describe '#write_file' do
+    it 'raises an NotImplementedError' do
+      expect{subject.write_file({})}.to raise_error NotImplementedError
     end
   end
 end

--- a/spec/lib/renogen/formatters/csv_spec.rb
+++ b/spec/lib/renogen/formatters/csv_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Renogen::Formatters::Csv do
+  describe '#write_ methods' do
+    let(:change_1) { renogen_change('Group 1', 'Change 1') }
+    let(:change_2) { renogen_change('Group 2', 'Change 2') }
+    let(:changes) { [change_1, change_2] }
+    let(:changelog) { Renogen::ChangeLog::Model.new }
+
+    before do
+      changes.each { |c| changelog.add_change(c) }
+    end
+
+    describe '#write_headings' do
+      it 'returns a comma separated list of group names' do
+        expect(subject.write_headings(changelog)).to eq('Group 1,Group 2')
+      end
+    end
+
+    describe '#write_file' do
+      let(:file) do
+        {
+          'Group 1' => 'This is a Group 1 change',
+          'Group 2' => 'This is a Group 2 change'
+        }
+      end
+
+      context 'when file contains same keys as changelog groups' do
+        it 'outputs all values' do
+          expect(subject.write_file(file, changelog)).to eq(
+            '"This is a Group 1 change","This is a Group 2 change"'
+          )
+        end
+      end
+
+      context 'when changelog contains keys missing in file' do
+        let(:change_3) { renogen_change('Group 3', 'Change 3') }
+        let(:changes) { [change_1, change_2, change_3] }
+
+        it 'outputs empty values for missing keys' do
+          expect(subject.write_file(file, changelog)).to eq(
+            '"This is a Group 1 change","This is a Group 2 change",""'
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/renogen/writers/csv_spec.rb
+++ b/spec/lib/renogen/writers/csv_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Renogen::Writers::Csv do
+  let(:formatter) { Renogen::Formatters::Csv.new }
+
+  subject { Renogen::Writers::Csv.new(formatter) }
+
+  describe '#write!' do
+    let(:expected_output) do
+      <<~EOS
+        Group 1,Group 2
+        "This is a Group 1 change","This is a Group 2 change"
+      EOS
+    end
+
+    let(:change_1) { renogen_change('Group 1', '') }
+    let(:change_2) { renogen_change('Group 2', '') }
+    let(:changelog) { Renogen::ChangeLog::Model.new }
+
+    before do
+      [change_1, change_2].each { |c| changelog.add_change(c) }
+      changelog.add_file({
+        'Group 1' => 'This is a Group 1 change',
+        'Group 2' => 'This is a Group 2 change'
+      })
+      $stdout = StringIO.new
+    end
+
+    after do
+      $stdout = STDOUT
+    end
+
+    it 'writes all CSV lines' do
+      subject.write!(changelog)
+      $stdout.rewind
+      expected_output.split("\n").each do |line|
+        expect($stdout.gets.strip).to eq(line)
+      end
+    end
+  end
+end
+

--- a/spec/lib/renogen/writers/html_spec.rb
+++ b/spec/lib/renogen/writers/html_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Renogen::Writers::Html do
+  let(:formatter) { Renogen::Formatters::Html.new }
+
+  subject { Renogen::Writers::Html.new(formatter) }
+
+  describe '#write!' do
+    let(:expected_output) do
+      <<~EOS
+        <html>
+        <h1>test (2020-01-14)</h1>
+        <h2>Group 1</h2>
+        <ul>
+        <li>This is a Group 1 change
+        </li>
+        </ul>
+        <h2>Group 2</h2>
+        <ul>
+        <li>This is a Group 2 change
+        </li>
+        </ul>
+        </html>
+      EOS
+    end
+
+    let(:change_1) { renogen_change('Group 1', 'This is a Group 1 change') }
+    let(:change_2) { renogen_change('Group 2', 'This is a Group 2 change') }
+    let(:changelog) do
+      Renogen::ChangeLog::Model.new(
+        version: 'test',
+        date: Date.new(2020, 1, 14)
+      )
+    end
+
+    before do
+      [change_1, change_2].each { |c| changelog.add_change(c) }
+      $stdout = StringIO.new
+    end
+
+    after do
+      $stdout = STDOUT
+    end
+
+    it 'writes all HTML lines' do
+      subject.write!(changelog)
+      $stdout.rewind
+
+      expected_output.split("\n").each do |line|
+        expect($stdout.gets.strip).to eq(line)
+      end
+    end
+  end
+end
+

--- a/spec/lib/renogen/writers/markdown_spec.rb
+++ b/spec/lib/renogen/writers/markdown_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Renogen::Writers::Markdown do
+  let(:formatter) { Renogen::Formatters::Markdown.new }
+
+  subject { Renogen::Writers::Markdown.new(formatter) }
+
+  describe '#write!' do
+    let(:expected_output) do
+      <<~EOS
+        # test (2020-01-14)
+
+        ## Group 1
+
+        * This is a Group 1 change
+
+        ## Group 2
+
+        * This is a Group 2 change
+      EOS
+    end
+
+    let(:change_1) { renogen_change('Group 1', 'This is a Group 1 change') }
+    let(:change_2) { renogen_change('Group 2', 'This is a Group 2 change') }
+    let(:changelog) do
+      Renogen::ChangeLog::Model.new(
+        version: 'test',
+        date: Date.new(2020, 1, 14)
+      )
+    end
+
+    before do
+      [change_1, change_2].each { |c| changelog.add_change(c) }
+      $stdout = StringIO.new
+    end
+
+    after do
+      $stdout = STDOUT
+    end
+
+    it 'writes all Markdown lines' do
+      subject.write!(changelog)
+      $stdout.rewind
+
+      expected_output.split("\n").each do |line|
+        expect($stdout.gets.strip).to eq(line)
+      end
+    end
+  end
+end
+

--- a/spec/lib/renogen/writers/plain_text_spec.rb
+++ b/spec/lib/renogen/writers/plain_text_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Renogen::Writers::PlainText do
+  let(:formatter) { Renogen::Formatters::PlainText.new }
+
+  subject { Renogen::Writers::PlainText.new(formatter) }
+
+  describe '#write!' do
+    let(:expected_output) do
+      <<~EOS
+        test (2020-01-14)
+
+        Group 1
+        - This is a Group 1 change
+
+        Group 2
+        - This is a Group 2 change
+      EOS
+    end
+
+    let(:change_1) { renogen_change('Group 1', 'This is a Group 1 change') }
+    let(:change_2) { renogen_change('Group 2', 'This is a Group 2 change') }
+    let(:changelog) do
+      Renogen::ChangeLog::Model.new(
+        version: 'test',
+        date: Date.new(2020, 1, 14)
+      )
+    end
+
+    before do
+      [change_1, change_2].each { |c| changelog.add_change(c) }
+      $stdout = StringIO.new
+    end
+
+    after do
+      $stdout = STDOUT
+    end
+
+    it 'writes all Text lines' do
+      subject.write!(changelog)
+      $stdout.rewind
+
+      expected_output.split("\n").each do |line|
+        expect($stdout.gets.strip).to eq(line)
+      end
+    end
+  end
+end
+

--- a/spec/lib/renogen/writers_spec.rb
+++ b/spec/lib/renogen/writers_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Renogen::Writers do
+  describe '.obtain' do
+    module Renogen
+      module Writers
+        class RichTextWriter < Base
+          register :rtf
+        end
+      end
+    end
+
+    module Renogen
+      module Writers
+        class DefaultWriter < Base
+          register :default
+        end
+      end
+    end
+
+    context 'when a writer is registered for the given format' do
+      it 'returns instance of the writer for the specified format' do
+        expect(subject.obtain(:rtf, Renogen::Formatters::Base.new))
+          .to be_instance_of(Renogen::Writers::RichTextWriter)
+      end
+    end
+
+    context 'when a writer is not registered for the given format' do
+      it 'returns instance of the default writer' do
+        expect(subject.obtain(:json, Renogen::Formatters::Base.new))
+          .to be_instance_of(Renogen::Writers::DefaultWriter)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'renogen'
+require_relative 'support/renogen_helper'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
@@ -40,4 +41,6 @@ RSpec.configure do |config|
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = :random
+
+  config.include Support::RenogenHelper
 end

--- a/spec/support/renogen_helper.rb
+++ b/spec/support/renogen_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Support
+  module RenogenHelper
+    def renogen_change(group_name, change)
+      Renogen::ChangeLog::Item.new(group_name, change)
+    end
+  end
+end


### PR DESCRIPTION
This PR looks like it changes a lot, but it mostly just restructures a few things. When outputting changes to CSV, the most likely expected result would be each change as a row with the group headings as the column names. Existing formats are output group by group with the content for each change sorted under each heading.

To enable CSV to behave differently, this PR chiefly amends writers to function in a similar fashion to formatters. Different writers can now be registered for different formats, and can customise the order in which it renders the formatted output.

The base writer class (functionally the same as the previous `Writer` class) is registered as the default writer used if a custom writer isn't found for a specific format. This will ensure compatibility with any existing custom formatters in use.

Another addition is the inclusion of the raw hash contents read from each YAML change file as an extra collection on the `ChangeLog::Model` object. This was necessary to retain the context needed for the CSV output, and could also be leveraged by custom writers to enable different types of output in the future. 

Also adds some tests for the different output formats 🙂 