### PR TITLE
Adjust ruby version in gem-specifications to be compatible with ruby 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.4.1
+
+## Minor Improvement
+
+* Adds support for ruby v3
+
 # 1.4.0
 
 ## Improvement

--- a/renogen.gemspec
+++ b/renogen.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/DDAZZA/renogen'
   s.license     = 'GPL-3.0'
   s.executables << 'renogen'
-  s.required_ruby_version = '~> 2.0'
+  s.required_ruby_version = '>= 2.0'
 
   # Required development dependencies
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
Making this small adjustment to the `required_ruby_version` in the gem-specifications, so that we can still use the gem when updating to ruby 3.
Merging this would really help us with our dependency issue. Thank you!